### PR TITLE
Return a 200 instead of a 404/500 if the user has no streams

### DIFF
--- a/api/streams.go
+++ b/api/streams.go
@@ -51,7 +51,11 @@ func init() {
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			member, err := DB.MemberByAny(mux.Vars(r)["memberID"])
-			if err == gorm.ErrRecordNotFound {
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if err == gorm.ErrRecordNotFound || member == nil {
 				http.NotFound(w, r)
 				return
 			}

--- a/api/streams.go
+++ b/api/streams.go
@@ -60,11 +60,7 @@ func init() {
 				return
 			}
 			stream, err := DB.StreamByMemberID(member.ID)
-			if err == gorm.ErrRecordNotFound {
-				http.NotFound(w, r)
-				return
-			}
-			if err != nil {
+			if err != nil && err != gorm.ErrRecordNotFound {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}


### PR DESCRIPTION
Currently the member page doesn't load because the UI doesn't handle the error response correctly. This is because the Streams API is returning a 404 response if there are no streams for the user. Now we only return 500 if an error other than no record occurs. This allows the member page to load, and enables the editability for members so they can input their own stream info.

If the member has no streams, we just return the JSON with the empty values.