### PR TITLE
Integrating with Discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dashboard
 ui/ab0x.go
 cfg-slack.yml
+cfg-discord.yml
 cfg-api.yml
 cfg-db.yml
 cfg-events.yml

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ _testmain.go
 *.test
 *.prof
 .idea
-vendor

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea
+vendor

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   version = "v1.3.1"
 
 [[projects]]
+  name = "github.com/bwmarrin/discordgo"
+  packages = ["."]
+  revision = "4a33b9bc7c56cfdb9bb244e33e83cb3941fe2bdc"
+  version = "v0.18.0"
+
+[[projects]]
   name = "github.com/dineshappavoo/basex"
   packages = ["."]
   revision = "f35bafba529cfea4a0b09b55ba1588e894658299"
@@ -56,8 +62,17 @@
   version = "v1.1"
 
 [[projects]]
+  name = "github.com/gorilla/websocket"
+  packages = ["."]
+  revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/jinzhu/gorm"
-  packages = [".","dialects/mysql"]
+  packages = [
+    ".",
+    "dialects/mysql"
+  ]
   revision = "5174cc5c242a728b435ea2be8a2f7f998e15429b"
   version = "v1.0"
 
@@ -75,7 +90,10 @@
 
 [[projects]]
   name = "github.com/labstack/gommon"
-  packages = ["color","log"]
+  packages = [
+    "color",
+    "log"
+  ]
   revision = "57409ada9da0f2afad6664c49502f8c50fbd8476"
   version = "0.2.3"
 
@@ -147,14 +165,36 @@
 
 [[projects]]
   name = "go.uber.org/zap"
-  packages = [".","buffer","internal/bufferpool","internal/color","internal/exit","zapcore"]
+  packages = [
+    ".",
+    "buffer",
+    "internal/bufferpool",
+    "internal/color",
+    "internal/exit",
+    "zapcore"
+  ]
   revision = "35aad584952c3e7020db7b839f6b102de6271f89"
   version = "v1.7.1"
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/crypto"
+  packages = [
+    "nacl/secretbox",
+    "poly1305",
+    "salsa20/salsa"
+  ]
+  revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","webdav","webdav/internal/xml","websocket"]
+  packages = [
+    "context",
+    "webdav",
+    "webdav/internal/xml",
+    "websocket"
+  ]
   revision = "ab555f366c4508dbe0802550b1b20c46c5c18aa0"
 
 [[projects]]
@@ -178,6 +218,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "02791b4c3911e08516cb789d6eebbd0cf9f9d9e767b5b503a3c3603930a726e8"
+  inputs-digest = "fe034c6859a774f8eb67234cfe01bc32a5819e6a14c1609daa88706fd2586a28"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -96,3 +96,7 @@
 [[constraint]]
   name = "gopkg.in/djherbis/stow.v2"
   version = "2.2.0"
+
+[[constraint]]
+  name = "github.com/bwmarrin/discordgo"
+  version = "0.18.0"

--- a/bot/discord.go
+++ b/bot/discord.go
@@ -1,0 +1,66 @@
+package bot
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"go.uber.org/zap"
+	"fmt"
+	"github.com/FederationOfFathers/dashboard/messaging"
+)
+
+var logger = messaging.Logger
+
+type DiscordAPI struct {
+	Token string
+	discord *discordgo.Session
+	streamNoticeChannelId string
+}
+
+func NewDiscordAPI(token string, streamChannelId string) DiscordAPI {
+	return DiscordAPI{
+		Token: token,
+		streamNoticeChannelId: streamChannelId,
+	}
+}
+
+// Needs to be called before any other API function work
+func (d *DiscordAPI) Connect() {
+	dg, err := discordgo.New("Bot " + d.Token)
+	if err != nil {
+		logger.Error("Unable to create discord connection", zap.Error(err))
+		return
+	}
+
+	d.discord = dg
+	dg.Open()
+}
+
+// Needs to be called to disconnect from discord
+func (d *DiscordAPI) Shutdown() {
+	d.discord.Close()
+}
+
+func (d DiscordAPI) PostStreamMessage(sm messaging.StreamMessage) error {
+	if d.discord == nil {
+		return fmt.Errorf("discord API not connected")
+	}
+	author := discordgo.MessageEmbedAuthor{
+		Name: fmt.Sprintf("%s is live!", sm.Username),
+	}
+	thumbnail := discordgo.MessageEmbedThumbnail{
+		URL: sm.UserLogo,
+	}
+	footer := discordgo.MessageEmbedFooter{
+		Text: sm.Platform,
+		IconURL: sm.PlatformLogo,
+	}
+	messageEmbed := discordgo.MessageEmbed{
+		Description: fmt.Sprintf("**Game:** %s\n%s\n%s", sm.Game, sm.Description, sm.URL),
+		Color: sm.PlatformColorInt,
+		URL: sm.URL,
+		Author: &author,
+		Thumbnail: &thumbnail,
+		Footer: &footer,
+	}
+	_, err := d.discord.ChannelMessageSendEmbed(d.streamNoticeChannelId, &messageEmbed)
+	return err
+}

--- a/bot/discord.go
+++ b/bot/discord.go
@@ -43,6 +43,9 @@ func (d DiscordAPI) PostStreamMessage(sm messaging.StreamMessage) error {
 	if d.discord == nil {
 		return fmt.Errorf("discord API not connected")
 	}
+	if d.streamNoticeChannelId == "" {
+		return fmt.Errorf("stream channel id not configured")
+	}
 	author := discordgo.MessageEmbedAuthor{
 		Name: fmt.Sprintf("%s is live!", sm.Username),
 	}

--- a/bot/discord.go
+++ b/bot/discord.go
@@ -50,16 +50,23 @@ func (d DiscordAPI) PostStreamMessage(sm messaging.StreamMessage) error {
 		URL: sm.UserLogo,
 	}
 	footer := discordgo.MessageEmbedFooter{
-		Text: sm.Platform,
+		Text: fmt.Sprintf("%s | %s", sm.Platform, sm.Timestamp),
 		IconURL: sm.PlatformLogo,
 	}
 	messageEmbed := discordgo.MessageEmbed{
-		Description: fmt.Sprintf("**Game:** %s\n%s\n%s", sm.Game, sm.Description, sm.URL),
+		Description: sm.URL,
 		Color: sm.PlatformColorInt,
 		URL: sm.URL,
 		Author: &author,
 		Thumbnail: &thumbnail,
 		Footer: &footer,
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name: "Game",
+				Value: fmt.Sprintf("%s - %s", sm.Game, sm.Description),
+				Inline: false,
+			},
+		},
 	}
 	_, err := d.discord.ChannelMessageSendEmbed(d.streamNoticeChannelId, &messageEmbed)
 	return err

--- a/bot/slack.go
+++ b/bot/slack.go
@@ -74,7 +74,7 @@ func SlackConnect(slackToken string) error {
 	}()
 	messagingClient = &rtm.Client
 	if MessagingKey != "" {
-		Logger.Warn("Using special key for fofbot messaging", zap.String("key", MessagingKey))
+		Logger.Warn("Using special key for fofbot messaging")
 		messagingClient = slack.New(MessagingKey)
 	} else {
 		Logger.Warn("Using default client for fofbot messaging")

--- a/bot/slack.go
+++ b/bot/slack.go
@@ -288,6 +288,9 @@ func (s SlackAPI) PostStreamMessage(sm messaging.StreamMessage) error {
 	if s.Slack == nil {
 		return fmt.Errorf("slack API not connected")
 	}
+	if s.streamNoticeChannelId == "" {
+		return fmt.Errorf("stream channel id not configured")
+	}
 
 	messageParams := slack.NewPostMessageParameters()
 	message := fmt.Sprintf("*%s is live!* - %s", sm.Username, sm.URL)

--- a/cfg-discord.yml.example
+++ b/cfg-discord.yml.example
@@ -1,0 +1,2 @@
+discordBotToken: ""
+discordStreamChannelId: ""

--- a/clients/mixer/mixer.go
+++ b/clients/mixer/mixer.go
@@ -1,0 +1,23 @@
+package mixer
+
+import (
+	"fmt"
+	"time"
+)
+
+// since there is no go library for mixer, we should move api calls to a separate package
+
+type Mixer struct {
+	BeamUsername string
+	ChannelID    int64
+	Online       bool
+	Title        string
+	Game         string
+	StartedAt    string
+	StartedTime  time.Time
+	AvatarUrl    string
+}
+
+func (m Mixer) GetChannelUrl() string {
+	return fmt.Sprintf("https://mixer.com/%s", m.BeamUsername)
+}

--- a/main.go
+++ b/main.go
@@ -53,12 +53,14 @@ func init() {
 	scfg.StringVar(&streamChannel, "streamChannel", streamChannel, "where to send streaming notices")
 	scfg.BoolVar(&mindStreams, "mindStreams", mindStreams, "should we mind streaming?")
 
+	discfg := cfg.New("cfg-discord")
+	discfg.StringVar(&discordBotToken, "discordBotToken", discordBotToken, "Discord Bot Token")
+	discfg.StringVar(&discordStreamChannelId, "discordStreamChannelId", discordStreamChannelId, "Discord Stream Channel ID")
+
 	acfg := cfg.New("cfg-api")
 	acfg.StringVar(&api.ListenOn, "listen", api.ListenOn, "API bind address (env: API_LISTEN)")
 	acfg.StringVar(&api.AuthSecret, "secret", api.AuthSecret, "Authentication secret for use in generating login tokens")
 	acfg.StringVar(&api.JWTSecret, "hmac", api.JWTSecret, "Authentication secret used for JWT tokens")
-	acfg.StringVar(&discordBotToken, "discordBotToken", discordBotToken, "Discord Bot Token")
-	acfg.StringVar(&discordStreamChannelId, "discordStreamChannelId", discordStreamChannelId, "Discord Stream Channel ID")
 
 	ecfg := cfg.New("cfg-events")
 	ecfg.StringVar(&events.SaveFile, "savefile", events.SaveFile, "path to the file in which events should be persisted")
@@ -118,7 +120,7 @@ func main() {
 
 	streams.Init(streamChannel)
 	if mindStreams {
-		logger.Info("Minding streams", zap.String("channel", streamChannel), zap.String("twitch_client_id", twitchClientID))
+		logger.Info("Minding streams", zap.String("channel", streamChannel))
 		streams.MustTwitch(twitchClientID)
 		streams.Mind()
 	} else {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/FederationOfFathers/dashboard/bridge"
 	"github.com/FederationOfFathers/dashboard/db"
 	"github.com/FederationOfFathers/dashboard/events"
+	"github.com/FederationOfFathers/dashboard/messaging"
 	"github.com/FederationOfFathers/dashboard/store"
 	"github.com/FederationOfFathers/dashboard/streams"
 	"github.com/apokalyptik/cfg"
@@ -19,6 +20,8 @@ import (
 var twitchClientID = ""
 var slackAPIKey = "xox...."
 var slackMessagingKey = ""
+var discordBotToken = ""
+var discordStreamChannelId = ""
 var logger *zap.Logger
 var devPort = 0
 var DB *db.DB
@@ -39,6 +42,7 @@ func init() {
 	streams.Logger = logger.With(zap.String("module", "streams"))
 	db.Logger = logger.With(zap.String("module", "db"))
 	bridge.Logger = logger.With(zap.String("module", "bridge"))
+	messaging.Logger = logger.With(zap.String("module", "messaging"))
 
 	scfg := cfg.New("cfg-slack")
 	scfg.StringVar(&slackAPIKey, "apiKey", slackAPIKey, "Slack API Key (env: SLACK_APIKEY)")
@@ -53,6 +57,8 @@ func init() {
 	acfg.StringVar(&api.ListenOn, "listen", api.ListenOn, "API bind address (env: API_LISTEN)")
 	acfg.StringVar(&api.AuthSecret, "secret", api.AuthSecret, "Authentication secret for use in generating login tokens")
 	acfg.StringVar(&api.JWTSecret, "hmac", api.JWTSecret, "Authentication secret used for JWT tokens")
+	acfg.StringVar(&discordBotToken, "discordBotToken", discordBotToken, "Discord Bot Token")
+	acfg.StringVar(&discordStreamChannelId, "discordStreamChannelId", discordStreamChannelId, "Discord Stream Channel ID")
 
 	ecfg := cfg.New("cfg-events")
 	ecfg.StringVar(&events.SaveFile, "savefile", events.SaveFile, "path to the file in which events should be persisted")
@@ -83,6 +89,7 @@ func main() {
 		bot.LoginLink = fmt.Sprintf("http://fofgaming.com%s/", api.ListenOn)
 	}
 
+	// start a separate message Slack connection if there is a separate messaging key
 	if slackMessagingKey != "" {
 		bot.MessagingKey = slackMessagingKey
 	} else {
@@ -92,10 +99,22 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to contact the slack API", zap.Error(err))
 	}
+	slackApi := bot.NewSlackAPI(bot.MessagingKey, streamChannel)
+	slackApi.Connect()
+	defer slackApi.Shutdown()
+	messaging.AddMsgAPI(slackApi)
 
 	bridge.SlackCoreDataUpdated = bot.SlackCoreDataUpdated
 	bridge.OldEventToolLink = events.OldEventToolLink
 	bridge.OldEventToolAuthorization = events.OldEventToolAuthorization
+
+	// start discord bot
+	if discordBotToken != "" {
+		discordApi := bot.NewDiscordAPI(discordBotToken, discordStreamChannelId)
+		discordApi.Connect()
+		defer discordApi.Shutdown()
+		messaging.AddMsgAPI(discordApi)
+	}
 
 	streams.Init(streamChannel)
 	if mindStreams {

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -4,6 +4,7 @@ import (
 	"github.com/FederationOfFathers/dashboard/clients/mixer"
 	"github.com/knspriggs/go-twitch"
 	"go.uber.org/zap"
+	"time"
 )
 
 var msgApis []MsgAPI
@@ -19,6 +20,7 @@ type StreamMessage struct {
 	URL              string
 	Game             string
 	Description      string
+	Timestamp        string
 }
 
 // Add Messaging APIs that will be used to send messages
@@ -46,6 +48,7 @@ func SendTwitchStreamMessage(t twitch.StreamType) {
 		URL:              t.Channel.URL,
 		Game:             playing,
 		Description:      t.Channel.Status,
+		Timestamp:        time.Now().Format("01/02/2006 15:04 MST"),
 	}
 	postStreamMessageToAllApis(sm)
 }
@@ -60,6 +63,7 @@ func SendMixerStreamMessage(m mixer.Mixer) {
 		URL:              m.GetChannelUrl(),
 		Game:             m.Game,
 		Description:      m.Title,
+		Timestamp:        time.Now().Format("01/02/2006 15:04 MST"),
 	}
 	postStreamMessageToAllApis(sm)
 }

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -5,6 +5,7 @@ import (
 	"github.com/knspriggs/go-twitch"
 	"go.uber.org/zap"
 	"time"
+	"reflect"
 )
 
 var msgApis []MsgAPI
@@ -25,6 +26,7 @@ type StreamMessage struct {
 
 // Add Messaging APIs that will be used to send messages
 func AddMsgAPI(msgApi MsgAPI) {
+	Logger.Info("Adding new message API",zap.String("type", reflect.TypeOf(msgApi).String()))
 	msgApis = append(msgApis, msgApi)
 }
 


### PR DESCRIPTION
Added functionality to send stream updates to both Slack and Discord. This allows the data from the team tool to be used for updating both slack and discord (Until we are fully assimilated to the discord hive mind)
* Slack still works without making any changes
* Slack messages and Discord messages now follow a similar format (See screenshots below)
* Slack specific user `@` mentions are removed. Channel usernames are displayed
* To add discord:
    * [Click the link to authorize fof-bot to the discord server](https://discordapp.com/api/oauth2/authorize?client_id=447447191640997888&permissions=518144&redirect_uri=https%3A%2F%2Fui.fofgaming.com&response_type=code&scope=bot%20messages.read) (Needs to be done by an owner)
    * add a cfg-discord.yml file with the following:
        * `discordBotToken`: bot token used to authenticate with discord (I can provide this)
        * `discordStreamChannelId`: The id of the channel to post the stream notifications


### Notification Screenshots
Slack Notification:
![image](https://user-images.githubusercontent.com/1667247/40524163-ffb3cd0c-5fa6-11e8-9759-4700bd069e0a.png)

Discord Notification:
![image](https://user-images.githubusercontent.com/1667247/40524167-0876960e-5fa7-11e8-9104-c241fa27159d.png)

